### PR TITLE
base_path without slash

### DIFF
--- a/lib/gollum-site/layout/_Layout.html
+++ b/lib/gollum-site/layout/_Layout.html
@@ -4,15 +4,15 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="{{ wiki.base_path }}css/screen.css" type="text/css" charset="utf-8" />
-    <link rel="stylesheet" href="{{ wiki.base_path }}css/gollum.css" type="text/css" charset="utf-8" />
-    <link rel="stylesheet" href="{{ wiki.base_path }}css/syntax.css" type="text/css" charset="utf-8" />
-    <script src="{{ wiki.base_path }}javascript/jquery-1.4.2.min.js" type="text/javascript"></script>
-    <script src="{{ wiki.base_path }}javascript/jquery.text_selection-1.0.0.min.js" type="text/javascript"></script>
-    <script src="{{ wiki.base_path }}javascript/jquery.previewable_comment_form.js" type="text/javascript"></script>
-    <script src="{{ wiki.base_path }}javascript/jquery.tabs.js" type="text/javascript"></script>
-    <script src="{{ wiki.base_path }}javascript/gollum.js" type="text/javascript"></script>
-    <script src="{{ wiki.base_path }}javascript/MathJax/MathJax.js" type="text/javascript">
+    <link rel="stylesheet" href="{{ wiki.base_path }}/css/screen.css" type="text/css" charset="utf-8" />
+    <link rel="stylesheet" href="{{ wiki.base_path }}/css/gollum.css" type="text/css" charset="utf-8" />
+    <link rel="stylesheet" href="{{ wiki.base_path }}/css/syntax.css" type="text/css" charset="utf-8" />
+    <script src="{{ wiki.base_path }}/javascript/jquery-1.4.2.min.js" type="text/javascript"></script>
+    <script src="{{ wiki.base_path }}/javascript/jquery.text_selection-1.0.0.min.js" type="text/javascript"></script>
+    <script src="{{ wiki.base_path }}/javascript/jquery.previewable_comment_form.js" type="text/javascript"></script>
+    <script src="{{ wiki.base_path }}/javascript/jquery.tabs.js" type="text/javascript"></script>
+    <script src="{{ wiki.base_path }}/javascript/gollum.js" type="text/javascript"></script>
+    <script src="{{ wiki.base_path }}/javascript/MathJax/MathJax.js" type="text/javascript">
       MathJax.OutputJax.fontDir = "http://github-assets.s3.amazonaws.com/javascripts/MathJax/fonts"
       MathJax.Hub.Config({
       jax: ["input/TeX", "output/HTML-CSS"]


### PR DESCRIPTION
I think this change fixes the problem in issue #3. In the code, base_path is used with File.join and a slash is added automatically.

If for some reason you don't want to do this change, please consider adding a note to README.md.

Thanks!
