### PR TITLE
custom ignorefile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ You can customize sanitization with three options:
 
        $ gollum-site generate --allow_elements embed,object --allow_attributes src --allow_protocols irc
 
+## Ignore File
+
+If there is a file named `.gollumignore` in the root of the repository, the
+exclusions it specifies will be used to suppress gollum-site generation
+accordingly. The `.gollumignore` file uses `.gitignore` semantics.
+
 ## Example
 
 To see gollum-site in action, let's use it to generate a static site from a


### PR DESCRIPTION
a `.gollumignore` file using `.gitignore` semantics will be used if
present to govern what gollum-site generates.
- consolidated all `site.rb` ignore behavior
- added test for gollumignore
