### PR TITLE
[[Page#Anchor]] links don't seem to work

### DIFF
--- a/lib/gollum-site/site.rb
+++ b/lib/gollum-site/site.rb
@@ -11,7 +11,7 @@ module Gollum
 
     def initialize(path, options = {})
       @wiki = Gollum::Wiki.new(path, {
-                                 :markup_class => Gollum::SiteMarkup,
+                                 :markup_classes => Hash.new(Gollum::SiteMarkup),
                                  :page_class => Gollum::SitePage,
                                  :base_path => options[:base_path],
                                  :sanitization => sanitization(options),

--- a/lib/gollum-site/version.rb
+++ b/lib/gollum-site/version.rb
@@ -1,5 +1,5 @@
 module Gollum
   class Site
-    VERSION = "0.1.11"
+    VERSION = "0.1.12"
   end
 end


### PR DESCRIPTION
Fixes issue #14

The gemspec is using Gollum >= 1.2.0. With 1.4.3, markup_class is not a valid parameter to the initialize method -- instead, it needs markup_classes.

I ran your test suite against this change, and everything passed. However, I'm not a Ruby developer, so please ensure this change isn't otherwise destructive before accepting.
