### PR TITLE
Page find method signature should be corrected

### DIFF
--- a/lib/gollum-site/page.rb
+++ b/lib/gollum-site/page.rb
@@ -15,7 +15,7 @@ module Gollum
     end
 
     # Markup uses this method for absent/present class assignment on page links
-    def find(cname, version)
+    def find(cname, version, dir = nil, exact = false)
       name = self.class.canonicalize_filename(cname)
       @wiki.site.pages[name.downcase]
     end


### PR DESCRIPTION
Made a simple change to a method signature to address a stack trace when trying to generate a gollum site (with gollum version 2.4.11 installed).

The commit aims to resolve https://github.com/dreverri/gollum-site/issues/25.

```
commit 963c2e9
Author: Marcus Pemer <marcus@iteego.com>
Date:   Fri Jan 25 09:51:19 2013 +0100

    Matched signature of find method with that of the parent class from gollum 2.4.11.

    The mismatch in signature caused a stacktrace when trying to generate a site.

:100644 100644 357f9ba... c72584d... M  lib/gollum-site/page.rb
```
