### PR TITLE
adding optional ability to preserve the original wiki directory structure

### DIFF
--- a/bin/gollum-site
+++ b/bin/gollum-site
@@ -60,6 +60,10 @@ opts = OptionParser.new do |opts|
     options['watch'] = true
   end
 
+  opts.on("--preserve", "Preserve directory structure for wiki documents") do
+    options['preserve'] = true
+  end
+
   opts.on("--allow_elements ELMS", "Custom elements to prevent sanitization (comma separated)") do |elements|
     options['allow_elements'] = elements.split(',')
   end
@@ -108,6 +112,7 @@ when 'generate'
                             :base_path => options['base_path'],
                             :output_path => options['output_path'],
                             :version => options['working'] ? :working : options['ref'],
+                            :preserve_tree => options['preserve'],
                             :allow_elements => options['allow_elements'],
                             :allow_attributes => options['allow_attributes'],
                             :allow_protocols => options['allow_protocols']
@@ -121,7 +126,8 @@ when 'serve'
     site = Gollum::Site.new('.', {
                             :base_path => options['base_path'],
                             :output_path => options['output_path'],
-                            :version => :working
+                            :version => :working,
+                            :preserve_tree => options['preserve'],
                             })
     puts "Generating site"
     start = Time.now

--- a/lib/gollum-site/page.rb
+++ b/lib/gollum-site/page.rb
@@ -39,7 +39,7 @@ module Gollum
     end
 
     # Output static HTML of current page
-    def generate(output_path, version)
+    def generate(output_path, version, preserve_path=false)
       data = if l = layout()
                SiteLog.debug("Found layout - #{name}")
                SiteLog.debug("Starting page rendering - #{name}")
@@ -53,7 +53,14 @@ module Gollum
                formatted_data
              end
 
-      ::File.open(::File.join(output_path, self.class.cname(name)), 'w') do |f|
+      if !preserve_path || path =~ /^\./
+        dest = ::File.join(output_path, self.class.cname(name))        
+      else
+        dest = ::File.join(output_path, ::File.dirname(path), self.class.cname(name))
+      end
+
+      ::FileUtils.mkdir_p(::File.dirname(dest))
+      ::File.open(dest, 'w') do |f|
         f.write(data)
       end
     end

--- a/lib/gollum-site/site.rb
+++ b/lib/gollum-site/site.rb
@@ -20,6 +20,7 @@ module Gollum
       @wiki.site = self
       @output_path = options[:output_path] || "_site"
       @version = options[:version] || "master"
+      @preserve_tree = options[:preserve_tree]
     end
 
     # Prepare site for specified version
@@ -43,7 +44,13 @@ module Gollum
           blob = OpenStruct.new(:name => filename, :data => item.data)
           page.populate(blob, dirname)
           page.version = @commit
-          @pages[page.name.downcase] = page
+
+          if @preserve_tree
+            key = [::File.dirname(item.path).gsub(/^\./, "").gsub(/\//, ' '), page.name].join(" ").strip.downcase
+          else
+            key = page.name.downcase
+          end
+          @pages[key] = page
         else
           # file
           @files[item.path] = item.data
@@ -84,7 +91,7 @@ module Gollum
 
       @pages.each do |name, page|
         SiteLog.debug("Starting page generation - #{name}")
-        page.generate(@output_path, @version)
+        page.generate(@output_path, @version, @preserve_tree)
         SiteLog.debug("Finished page generation - #{name}")
       end
 


### PR DESCRIPTION
So it started as a bug and ended as a feature...

I realized that if I had created a file in a subdirectory named the same as a file in the root dir or perhaps another subdirectory that only one of them would end up as the html file. It has to do with how site.rb stores the wiki pages in a hash rather than a list. Since the key wasn't factoring directory uniqueness, whichever was inserted last was the winner. Regardless of the optional feature I added (explained later) I would still consider this a bug. The only implication (the reason I didn't fix it completely) was because there appears to be a hard dependency for markup and how it generates link classes. Since I'm not fully aware of the implications, I decided to leave that bug exposed unless the --preserve flag was passed as an arg.

Which brings us to the feature... I realized that by default, gollum-site will take any wiki pages in any sub directories and create them as html files in a single document root directory. I tend to like subdirectories for clean organization so I added a "--preserve" flag as an option which will re-create the html files preserving the original directory structure. This is optional, and the default behavior remains. All tests are passing.

Thanks
